### PR TITLE
[Suggestion] Invent > Spread Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ our company and culture evolve, so should this document.
 - Teach others and help them grow in their abilities.
     - Teach your co-workers. Good venues for this are [Science Fair or the Engineering Meeting](https://mobify.atlassian.net/wiki/display/DEV/Engineering+Home).
     - Teach the community - for example speak at meetups ([VanJS)](http://www.meetup.com/vancouver-javascript-developers/), [VanPy](http://www.meetup.com/vanpyz/), [Web Performance](http://www.meetup.com/Vancouver-Web-Performance/), etc) or write blog posts.
+    - Transfer knowledge whenever possible. If someone encounters a problem it is better to guide them to a solution rather then solving it for them.
 - [Code reviews](https://mobify.atlassian.net/wiki/questions/79527980/answers/81789067) and Pair Programming are excellent strategies for learning new tricks.
     - Ensure people with different skill levels and skill sets are reviewing your code, it's a great opportunity for cross-pollination.
     - Get your code reviewed by the CTO at our [Engineering Office Hours](https://docs.google.com/document/d/1fvL30nvx1Yr2i--dTyytExnrokwrBQlPmXX2ZM06ukU/edit).
@@ -137,10 +138,6 @@ our company and culture evolve, so should this document.
 - Take pride in how you build the software and your craftsmanship regardless of how the product does in the market. This doesn't mean gold-plating everything, often you should act pragmatically. Shipping value to users is the most important thing, but make sure to take the time to reflect on what you build, and do a post mortem and always make sure you're not
 repeating the mistakes of the past.
 - Ensure you challenge designs that you see problems with instead of implementing them without questioning.
-
-#### Spread knowledge
-- Create documentation for the software you write (sometimes [even before you write it](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html))
-- Collaborate with others on their problems rather then solving everything for them. Provide others with the tools/knowledge/documentation they need to unblock themselves.
 
 #### Reach out to domain experts.
 - We value a collaborative development environment where we seek expertise from domain area experts. We have a wealth of expertise on the team with very talented folks - talk to them instead of making the mistake yourself! If you are unsure who to chat with, feel free to reach out to folks in the Engineering room on Slack, or reach out to your lead.
@@ -188,8 +185,17 @@ repeating the mistakes of the past.
       if (isRunningInApp)
       ```
 
-#### Write [Minimum Viable Documentation](https://mobify.atlassian.net/wiki/pages/viewpage.action?pageId=50266690#OurSoftwareDesign&DevelopmentProcess-MinimumViableDocumentation).
-- It's important to have minimal viable documentation for every module/library/plugin/product/etc that you create. It should probably be the [README](https://github.com/mobify/split-test/blob/master/README.md) of the project.
+#### Write [Minimum Viable Documentation](https://mobify.atlassian.net/wiki/pages/viewpage.action?pageId=50266690#OurSoftwareDesign&DevelopmentProcess-MinimumViableDocumentation)
+- All modules/libraries/plugins/etc. should have documentation that explains:
+    - Setup
+    - Usage
+    - Deployment
+    - Testing
+    - Contributing
+    - Roadmap/Changelog
+- Good documentation enables others to get up and running without your involvement.
+- Documentation should be updated as you write your software (or [even before you write it](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html)))
+- You should be able to answer the majority of questions from users with a link to a document.
 
 #### Be in touch with the dev community
 - Go to meetups and conferences and share what you've learned with the rest of the team.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ our company and culture evolve, so should this document.
 repeating the mistakes of the past.
 - Ensure you challenge designs that you see problems with instead of implementing them without questioning.
 
+#### Spread knowledge
+- Create documentation for the software you write (sometimes [even before you write it](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html))
+- Collaborate with others on their problems rather then solving everything for them. Provide others with the tools/knowledge/documentation they need to unblock themselves.
+
 #### Reach out to domain experts.
 - We value a collaborative development environment where we seek expertise from domain area experts. We have a wealth of expertise on the team with very talented folks - talk to them instead of making the mistake yourself! If you are unsure who to chat with, feel free to reach out to folks in the Engineering room on Slack, or reach out to your lead.
 


### PR DESCRIPTION
With recent talks of documentation and enabling partners, I've been thinking about "Spreading Knowledge" as a value (other suggestions also welcome). Moving from "Mobify knows how to build awesome web experiences" to "Anyone can use our tools to build amazing web experiences".

We should aim to have all our tools and practices documented as best as possible so that anyone can pick them up and get going:
- When questions/problems come up, we should try and have documentation we can point to that answers that question. 
- When problems don't have a solution worth documenting (eg. "I'm trying to fix a problem in this module, but I have no clue how it works") we should work with the person to guide them to a solution. This is in contrast to "Oh, if you don't know how to do just wait till X is free and they'll do it for you!".

#### Example of this in practice:
On web team we had a story to setup [Speedtrap](https://github.com/mobify/speedtrap) on a CST project. Doing that would possibly be the fastest way to get the tool setup, but it silos that information to Web team and doesn't allow us to validate our documentation.

Instead, CST should be given the repo and told to setup the tool. If they are unable to do so with the documentation provided, then that documentation needs to be updated. In addition, a member of Web team could sit with the user from CST and guide them through the process rather then setting it up for the user.

@johnboxall @jansepar @noahadams @donnielrt 
Thoughts? Comments? Additions? Subtractions?