### PR TITLE
Include PCI link in developer guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ a great responsiblity to never betray this trust:
 * 🔻 Apply the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).
 * 🤐 [Never commit secrets, keys or passwords](https://mobify.atlassian.net/wiki/display/SYS/Best+Practices+For+Keeping+Secrets+in+Applications).
 * ⏰ [Patch regularly](https://docs.google.com/document/d/1J3oC-7VJYC-wDLIF04M1jN79IhjF3sBLap0TUBJDVaw/edit#).
-* 💳 Be aware of our [PCI programme](https://mobify.atlassian.net/wiki/spaces/PCI/) and how it affects your work.
+* 💳 Be aware of our [Payment Card Industry (PCI) Standards programme](https://mobify.atlassian.net/wiki/spaces/PCI/) and how it affects your work.
 * 🙋 When in doubt, ask! [`#security`](https://mobify.slack.com/messages/security/) is always happy to help.
 
 ### Be Exceptional

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ a great responsiblity to never betray this trust:
 * 🔻 Apply the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).
 * 🤐 [Never commit secrets, keys or passwords](https://mobify.atlassian.net/wiki/display/SYS/Best+Practices+For+Keeping+Secrets+in+Applications).
 * ⏰ [Patch regularly](https://docs.google.com/document/d/1J3oC-7VJYC-wDLIF04M1jN79IhjF3sBLap0TUBJDVaw/edit#).
+* 💳 Be aware of our [PCI programme](https://mobify.atlassian.net/wiki/spaces/PCI/) and how it affects your work.
 * 🙋 When in doubt, ask! [`#security`](https://mobify.slack.com/messages/security/) is always happy to help.
 
 ### Be Exceptional


### PR DESCRIPTION
As discussed this week, let's mention PCI somewhere Mobifyers actually hang out.